### PR TITLE
Fix for Cut page errors hitting row 8

### DIFF
--- a/mlr.lua
+++ b/mlr.lua
@@ -744,6 +744,7 @@ v.gridkey[vCUT] = function(x, y, z)
   --print(held[y])
 
   if y == 1 then gridkey_nav(x,z)
+  elseif y == 8 then return
   else
     i = y-1
     if z == 1 then


### PR DESCRIPTION
https://llllllll.co/t/mlr-norns/21145/439?u=okyeron

Cut page would throw an error for `invalid paramset index: 7vol` when a key in bottom row was hit.

This is a workaround. Not sure what intended behavior should be.